### PR TITLE
Update chapter_03.rst

### DIFF
--- a/source/chapter_03.rst
+++ b/source/chapter_03.rst
@@ -644,10 +644,9 @@ hello handler 模块
 	static char *
 	ngx_http_hello_string(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 	{
-		ngx_http_core_loc_conf_t *clcf;
+	
 		ngx_http_hello_loc_conf_t* local_conf;
 		 
-		clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 		
 		local_conf = conf;
 		char* rv = ngx_conf_set_str_slot(cf, cmd, conf);
@@ -662,9 +661,6 @@ hello handler 模块
 		void *conf)
 	{
 		ngx_http_hello_loc_conf_t* local_conf;
-		ngx_http_core_loc_conf_t *clcf;
-
-		clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 		
 		local_conf = conf;
 		


### PR DESCRIPTION
删除掉未使用的clcf变量避免编译时出现-Werror=unused-variable错误。
